### PR TITLE
Add reference to web version of ES6 draft

### DIFF
--- a/references.json
+++ b/references.json
@@ -274,6 +274,12 @@
     "authors" : ["Ian Hickson"],
     "publisher" : "W3C"
   },
+  "ES6" :
+  {
+    "href" : "http://people.mozilla.org/~jorendorff/es6-draft.html",
+    "title" : "ECMA-262 6th Edition / Draft",
+    "publisher" : "ECMA / Jason Orendorff"
+  },
   "FILEAPI" :
   {
      "href" : "http://dev.w3.org/2006/webapi/FileAPI/",

--- a/specs.json
+++ b/specs.json
@@ -7,6 +7,7 @@
   "domps": "dom/domps.json",
   "editing": "dom/editing.json",
   "encoding": "network/encoding.json",
+  "es6": "js/es6.json",
   "fetch": "network/fetch.json",
   "fileapi": "dom/fileapi.json",
   "html": "dom/html-generated.json",

--- a/xrefs/js/es6.json
+++ b/xrefs/js/es6.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://people.mozilla.org/~jorendorff/es6-draft.html#",
+  "definitions":
+    {
+      "promise-objects": "sec-promise-objects"
+    }
+}


### PR DESCRIPTION
I am not sure this is the right approach, but could this be added as a means of deep-linking to ES6 while it's still a draft?