### PR TITLE
sync domexception

### DIFF
--- a/xrefs/dom/dom.json
+++ b/xrefs/dom/dom.json
@@ -450,7 +450,6 @@
     "domconfiguration": "domconfiguration",
     "domerror": "domerror",
     "domerrorhandler": "domerrorhandler",
-    "domexception": "domexception",
     "domimplementation": "domimplementation",
     "domimplementationlist": "domimplementationlist",
     "domimplementationsource": "domimplementationsource",

--- a/xrefs/dom/webidl.json
+++ b/xrefs/dom/webidl.json
@@ -7,6 +7,7 @@
     "code unit" : "dfn-code-unit",
     "convert a domstring to a sequence of unicode characters" : "dfn-obtain-unicode",
     "dictionary member": "dfn-dictionary-member",
+    "domexception": "idl-DOMException",
     "domstring": "idl-DOMString",
     "es-bytestring" : "es-ByteString",
     "float": "idl-float",


### PR DESCRIPTION
The [DOMException][1] type has moved to WebIDL.

[1]: https://heycam.github.io/webidl/#idl-DOMException