### PR TITLE
add webrtc ref and rtcdatachannel def

### DIFF
--- a/references.json
+++ b/references.json
@@ -557,6 +557,13 @@
     "authors" : ["Cameron McCormack"],
     "publisher" : "W3C"
   },
+  "WEBRTC" :
+  {
+    "href" : "https://w3c.github.io/webrtc-pc/",
+    "title" : "WebRTC",
+    "authors" : ["Ian Hickson", "Adam Bergkvist", "Daniel C. Burnett", "Cullen Jennings", "Anant Narayanan"],
+    "publisher" : "W3C"
+  },
   "XBL" :
   {
     "href" : "http://dev.w3.org/2006/xbl2/",

--- a/refs/dom/webrtc.json
+++ b/refs/dom/webrtc.json
@@ -1,0 +1,1 @@
+{"informative": [], "normative": []}

--- a/specs.json
+++ b/specs.json
@@ -19,6 +19,7 @@
   "url" : "network/url.json",
   "vibration" : "dom/vibration.json",
   "webidl": "dom/webidl.json",
+  "webrtc": "dom/webrtc.json",
   "xhr": "dom/xhr.json",
   "xml": "dom/xml.json",
   "xmlns": "dom/xmlns.json",

--- a/xrefs/dom/dom.json
+++ b/xrefs/dom/dom.json
@@ -450,7 +450,6 @@
     "domconfiguration": "domconfiguration",
     "domerror": "domerror",
     "domerrorhandler": "domerrorhandler",
-    "domexception": "domexception",
     "domimplementation": "domimplementation",
     "domimplementationlist": "domimplementationlist",
     "domimplementationsource": "domimplementationsource",

--- a/xrefs/dom/webidl.json
+++ b/xrefs/dom/webidl.json
@@ -7,6 +7,7 @@
     "code unit" : "dfn-code-unit",
     "convert a domstring to a sequence of unicode characters" : "dfn-obtain-unicode",
     "dictionary member": "dfn-dictionary-member",
+    "domexception": "idl-DOMException",
     "domstring": "idl-DOMString",
     "es-bytestring" : "es-ByteString",
     "float": "idl-float",

--- a/xrefs/dom/webrtc.json
+++ b/xrefs/dom/webrtc.json
@@ -1,0 +1,6 @@
+{
+  "url": "http://w3c.github.io/webrtc-pc/#",
+  "definitions": {
+    "rtcdatachannel" : "idl-def-RTCDataChannel"
+  }
+}


### PR DESCRIPTION
* Add [WebRTC][1] spec reference
* Add [RTCDataChannel][1] definition from the WebRTC spec, and intentionally only this one that is referenced elsewhere (and not the whole thing to make sync easy)

[1]: https://w3c.github.io/webrtc-pc/
[1]: https://w3c.github.io/webrtc-pc/#idl-def-RTCDataChannel